### PR TITLE
Remove duplicated route name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ configuration description
 ```text
 
 Route::any('/payment/momo/callback', 'PaymentMomoController@callback')->name('payment.momo.callback');
-Route::get('/payment/momo/transaction/{id}', 'PaymentMomoController@getPayment')->name('payment.momo.callback');
+Route::get('/payment/momo/transaction/{id}', 'PaymentMomoController@getPayment')->name('payment.momo.gettransaction');
 
 ```
 


### PR DESCRIPTION
Defined `gettransaction` as name of getPayment route in example code